### PR TITLE
Fix number & map type in dynamo_to_dict

### DIFF
--- a/examples/sam/sandbox.rst
+++ b/examples/sam/sandbox.rst
@@ -1,3 +1,4 @@
+Serverless Application Model
 
 .. code-block:: bash
 

--- a/sosw/components/dynamo_db.py
+++ b/sosw/components/dynamo_db.py
@@ -254,7 +254,9 @@ class DynamoDbClient:
                 val_dict = dynamo_row.get(key)  # Ex: {'N': "1234"} or {'S': "myvalue"}
                 if val_dict:
                     val = val_dict.get(key_type)  # Ex: 1234 or "myvalue"
-                    if key_type == 'S':
+                    if key_type == 'N':
+                        result[key] = float(val) if '.' in val else int(val)
+                    elif key_type == 'S':
                         # Try to load to a dictionary if looks like JSON.
                         if val.startswith('{') and val.endswith('}') and \
                                 not self.config.get('dont_json_loads_results'):
@@ -272,7 +274,9 @@ class DynamoDbClient:
         else:
             for key, val_dict in dynamo_row.items():
                 for val_type, val in val_dict.items():
-                    if val_type == 'S':
+                    if val_type == 'N':
+                        result[key] = float(val) if '.' in val else int(val)
+                    elif val_type == 'S':
                         # Try to load to a dictionary if looks like JSON.
                         if val.startswith('{') and val.endswith('}') and \
                                 not self.config.get('dont_json_loads_results'):

--- a/sosw/components/dynamo_db.py
+++ b/sosw/components/dynamo_db.py
@@ -349,7 +349,7 @@ class DynamoDbClient:
                 key_with_prefix = f"{add_prefix}{key}"
                 if isinstance(val, bool):
                     result[key_with_prefix] = {'BOOL': to_bool(val)}
-                elif isinstance(val, (int, float)) or (isinstance(val, str) and val.isnumeric()):
+                elif isinstance(val, (int, float)):
                     result[key_with_prefix] = {'N': str(val)}
                 elif isinstance(val, str):
                     result[key_with_prefix] = {'S': str(val)}

--- a/sosw/components/dynamo_db.py
+++ b/sosw/components/dynamo_db.py
@@ -254,6 +254,9 @@ class DynamoDbClient:
                 val_dict = dynamo_row.get(key)  # Ex: {'N': "1234"} or {'S': "myvalue"}
                 if val_dict:
                     val = val_dict.get(key_type)  # Ex: 1234 or "myvalue"
+
+                    # type_deserializer.deserialize() parses 'N' to `Decimal` type but it cant be parsed to a datetime
+                    # so we cast it to either an integer or a float.
                     if key_type == 'N':
                         result[key] = float(val) if '.' in val else int(val)
                     elif key_type == 'S':
@@ -274,6 +277,9 @@ class DynamoDbClient:
         else:
             for key, val_dict in dynamo_row.items():
                 for val_type, val in val_dict.items():
+
+                    # type_deserializer.deserialize() parses 'N' to `Decimal` type but it cant be parsed to a datetime
+                    # so we cast it to either an integer or a float.
                     if val_type == 'N':
                         result[key] = float(val) if '.' in val else int(val)
                     elif val_type == 'S':

--- a/sosw/components/dynamo_db.py
+++ b/sosw/components/dynamo_db.py
@@ -349,7 +349,7 @@ class DynamoDbClient:
                 key_with_prefix = f"{add_prefix}{key}"
                 if isinstance(val, bool):
                     result[key_with_prefix] = {'BOOL': to_bool(val)}
-                elif isinstance(val, (int, float)):
+                elif isinstance(val, (int, float)) or (isinstance(val, str) and val.isnumeric()):
                     result[key_with_prefix] = {'N': str(val)}
                 elif isinstance(val, str):
                     result[key_with_prefix] = {'S': str(val)}

--- a/sosw/components/dynamo_db.py
+++ b/sosw/components/dynamo_db.py
@@ -333,6 +333,8 @@ class DynamoDbClient:
                     result[key_with_prefix] = {'N': str(val)}
                 elif key_type == 'S':
                     result[key_with_prefix] = {'S': str(val)}
+                elif key_type == 'M':
+                    result[key_with_prefix] = {'M': self.dict_to_dynamo(val, strict=False)}
                 else:
                     result[key_with_prefix] = self.type_serializer.serialize(val)
 
@@ -351,6 +353,8 @@ class DynamoDbClient:
                     result[key_with_prefix] = {'N': str(val)}
                 elif isinstance(val, str):
                     result[key_with_prefix] = {'S': str(val)}
+                elif isinstance(val, dict):
+                    result[key_with_prefix] = {'M': self.dict_to_dynamo(val, strict=False)}
                 else:
                     result[key_with_prefix] = self.type_serializer.serialize(val)
             else:

--- a/sosw/components/test/unit/test_dynamo_db.py
+++ b/sosw/components/test/unit/test_dynamo_db.py
@@ -1,6 +1,7 @@
 import logging
 import unittest
 import os
+from decimal import Decimal
 
 from unittest.mock import MagicMock, patch, Mock
 
@@ -101,6 +102,8 @@ class dynamodb_client_UnitTestCase(unittest.TestCase):
         expected = {'lambda_name': 'test_name', 'invocation_id': 'test_id', 'en_time': 123456, 'some_bool': False,
                     'some_map': {'a': 1, 'b': 'b1', 'c': {'test': True}}, 'some_list': ['x', 'y']}
         self.assertDictEqual(expected, dict_row)
+        for k, v in dict_row.items():
+            self.assertNotIsInstance(v, Decimal)
 
 
     def test_dynamo_to_dict_no_strict_row_mapper(self):
@@ -114,6 +117,8 @@ class dynamodb_client_UnitTestCase(unittest.TestCase):
             'extra_key_s': 'wowie', 'other_bool': True
         }
         self.assertDictEqual(dict_row, expected)
+        for k, v in dict_row.items():
+            self.assertNotIsInstance(v, Decimal)
 
 
     def test_dynamo_to_dict__dont_json_loads(self):

--- a/sosw/components/test/unit/test_dynamo_db.py
+++ b/sosw/components/test/unit/test_dynamo_db.py
@@ -83,6 +83,17 @@ class dynamodb_client_UnitTestCase(unittest.TestCase):
             self.assertDictEqual(expected[key], dynamo_row[key])
 
 
+    def test_dict_to_dynamo__not_strict__map_type(self):
+        dict_row = {
+            'accept_mimetypes':     {'image/webp': 1, 'image/apng': 1, 'image/*': 1, '*/*': 0.8},
+        }
+        dynamo_row = self.dynamo_client.dict_to_dynamo(dict_row, strict=False)
+        expected = {}
+        logging.info(f"dynamo_row: {dynamo_row}")
+        for key in expected.keys():
+            self.assertDictEqual(expected[key], dynamo_row[key])
+
+
     def test_dict_to_dynamo_prefix(self):
         dict_row = {'hash_col': 'cat', 'range_col': '123', 'some_col': 'no'}
         dynamo_row = self.dynamo_client.dict_to_dynamo(dict_row, add_prefix="#")


### PR DESCRIPTION
In dynamo_to_dict, serializer returns Decimal type, and it's not always compatible with everything.

Also fixed a problem that when we transferred a dict with numbers, the numbers HAD to be decimals.