### PR TITLE
v0.7.29

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as f:
     long_description = f.read()
 
 setup(name='sosw',
-      version='0.7.27',
+      version='0.7.29',
       description='Serverless Orchestrator of Serverless Workers',
       long_description=long_description,
       long_description_content_type="text/markdown",

--- a/sosw/app.py
+++ b/sosw/app.py
@@ -78,6 +78,7 @@ class Processor:
         logger.info(f"Final {self.__class__.__name__} processor config: {self.config}")
 
         self.stats = defaultdict(int)
+        self.result = defaultdict(int)
 
         self.register_clients(self.config.get('init_clients', []))
 

--- a/sosw/components/dynamo_db.py
+++ b/sosw/components/dynamo_db.py
@@ -844,8 +844,9 @@ class DynamoDbClient:
         if condition_expression:
             expr, values = self._parse_filter_expression(condition_expression)
             update_item_query['ConditionExpression'] = expr
-            update_item_query['ExpressionAttributeValues'] = update_item_query.get('ExpressionAttributeValues', {})
-            update_item_query['ExpressionAttributeValues'].update(values)
+            if values:
+                update_item_query['ExpressionAttributeValues'] = update_item_query.get('ExpressionAttributeValues', {})
+                update_item_query['ExpressionAttributeValues'].update(values)
 
         logger.debug(f"Updating an item, query: {update_item_query}")
         response = self.dynamo_client.update_item(**update_item_query)

--- a/sosw/components/dynamo_db.py
+++ b/sosw/components/dynamo_db.py
@@ -84,10 +84,8 @@ class DynamoDbClient:
 
         self.config = config
 
-        if not str(config.get('table_name')).startswith('autotest_mock_'):
-            self.dynamo_client = boto3.client('dynamodb')
-        else:
-            logger.info(f"Initialized DynamoClient without boto3 client for table {config.get('table_name')}")
+        # create a dynamodb client
+        self.dynamo_client = boto3.client('dynamodb', region_name=config.get('region_name'))
 
         # storage for table description(s)
         self._table_descriptions: Optional[Dict[str, Dict]] = {}

--- a/sosw/components/dynamo_db.py
+++ b/sosw/components/dynamo_db.py
@@ -383,7 +383,8 @@ class DynamoDbClient:
     def get_by_query(self, keys: Dict, table_name: Optional[str] = None, index_name: Optional[str] = None,
                      comparisons: Optional[Dict] = None, max_items: Optional[int] = None,
                      filter_expression: Optional[str] = None, strict: bool = None, return_count: bool = False,
-                     desc: bool = False, fetch_all_fields: bool = None) -> Union[List[Dict], int]:
+                     desc: bool = False, fetch_all_fields: bool = None, expr_attrs_names: list = None) \
+            -> Union[List[Dict], int]:
         """
         Get an item from a table, by some keys. Can specify an index.
         If an index is not specified, will query the table.
@@ -415,6 +416,12 @@ class DynamoDbClient:
                              To reverse the order set the argument `desc = True`.
         :param bool fetch_all_fields: If False, will only get the attributes specified in the row mapper.
                                       If True, will get all attributes. Default is False.
+        :param list expr_attrs_names: List of attributes names, in case if an attribute name begins with a number or
+            contains a space, a special character, or a reserved word, you must use an expression attribute name to
+            replace that attribute's name in the expression.
+            Example, if the list ['session', 'key'] is received, then a new dict will be assigned to
+            `ExpressionAttributeNames`:
+            {'#session': 'session', '#key': 'key'}
 
         :return: List of items from the table, each item in key-value format
             OR the count if `return_count` is True
@@ -431,6 +438,10 @@ class DynamoDbClient:
         cond_expr_parts = []
 
         for key_attr_name in keys:
+            # Check if key attribute name is in `expr_attrs_names`, and create a prefix
+            # We add this prefix in case need to use `ExpressionAttributeNames`
+            expr_attr_prefix = '#' if expr_attrs_names and key_attr_name in expr_attrs_names else ''
+
             # Find comparison for key. The formatting of conditions could be different, so a little spaghetti.
             if key_attr_name.startswith('st_between_'):  # This is just a marker to construct a custom expression later
                 compr = 'between'
@@ -442,14 +453,15 @@ class DynamoDbClient:
                 compr = '='
 
             if compr == 'begins_with':
-                cond_expr_parts.append(f"begins_with ({key_attr_name}, :{key_attr_name})")
+                cond_expr_parts.append(f"begins_with ({expr_attr_prefix}{key_attr_name}, :{key_attr_name})")
 
             elif compr == 'between':
                 key = key_attr_name[11:]
-                cond_expr_parts.append(f"{key} between :st_between_{key} and :en_between_{key}")
+                expr_attr_prefix = '#' if expr_attrs_names and key in expr_attrs_names else ''
+                cond_expr_parts.append(f"{expr_attr_prefix}{key} between :st_between_{key} and :en_between_{key}")
             else:
                 assert compr in ('=', '<', '<=', '>', '>='), f"Comparison not valid: {compr} for {key_attr_name}"
-                cond_expr_parts.append(f"{key_attr_name} {compr} :{key_attr_name}")
+                cond_expr_parts.append(f"{expr_attr_prefix}{key_attr_name} {compr} :{key_attr_name}")
 
         cond_expr = " AND ".join(cond_expr_parts)
 
@@ -462,6 +474,11 @@ class DynamoDbClient:
             'ExpressionAttributeValues': filter_values,  # Ex: {':key1_name': 'key1_value', ...}
             'KeyConditionExpression':    cond_expr  # Ex: "key1_name = :key1_name AND ..."
         }
+
+        # In case of any of the attributes names are in the list of Reserved Words in DynamoDB or other situations when,
+        # there is a need to specify ExpressionAttributeNames, then a dict should be passed to the query.
+        if expr_attrs_names:
+            query_args['ExpressionAttributeNames'] = {f'#{el}': el for el in expr_attrs_names}
 
         # In case we have a filter expression, we parse it and add variables (values) to the ExpressionAttributeValues
         # Expression is also transformed to use these variables.

--- a/sosw/components/sns.py
+++ b/sosw/components/sns.py
@@ -70,6 +70,7 @@ class SnsManager():
             self.subject = kwargs.get('subject')
 
         self.queue = []
+        self.separator = "\n\n#####\n\n"
 
         self.test = kwargs.get('test') or True if os.environ.get('STAGE') == 'test' else False
         if self.test:
@@ -112,6 +113,15 @@ class SnsManager():
         self.set_client_attr('subject', value=str(value))
 
 
+    def set_separator(self, separator):
+        """
+        Set custom separator for messages from the queue
+        """
+
+        assert isinstance(separator, str), f"Invalid format of separator: {separator}. Separator must be string."
+        setattr(self, 'separator', separator)
+
+
     def commit(self):
         """
         Combines messages from self.queue and pushes them to self.recipient.
@@ -128,7 +138,7 @@ class SnsManager():
             raise RuntimeError("You did not specify Subject for the message. "
                                "We don't want you to write code like this, please fix.")
 
-        message = "\n\n#####\n\n".join(self.queue)
+        message = self.separator.join(self.queue)
 
         if message:
             self.client.publish(

--- a/sosw/components/test/integration/test_dynamo_db_i.py
+++ b/sosw/components/test/integration/test_dynamo_db_i.py
@@ -463,18 +463,18 @@ class DynamodbClientIntegrationTestCase(unittest.TestCase):
 
     def test_get_by_query__expr_attr(self):
         rows = [
-            {self.HASH_COL: 'cat1', self.RANGE_COL: 121, 'session': 'test1'},
-            {self.HASH_COL: 'cat1', self.RANGE_COL: 122, 'session': 'test2'},
-            {self.HASH_COL: 'cat1', self.RANGE_COL: 123, 'session': 'test3'}
+            {self.HASH_COL: 'cat1', self.RANGE_COL: 121},
+            {self.HASH_COL: 'cat1', self.RANGE_COL: 122},
+            {self.HASH_COL: 'cat1', self.RANGE_COL: 123}
         ]
 
         for x in rows:
             self.dynamo_client.put(x, table_name=self.table_name)
 
-        result = self.dynamo_client.get_by_query({self.HASH_COL: 'cat1'}, table_name=self.table_name,
-                                                 expr_attrs_names=['session'])
+        result = self.dynamo_client.get_by_query({self.HASH_COL: 'cat1', self.RANGE_COL: 121},
+                                                 table_name=self.table_name, expr_attrs_names=[self.HASH_COL])
 
-        self.assertEqual(result, 3)
+        self.assertEqual(result[0], rows[0])
 
 
     def test_get_by_query__reverse(self):

--- a/sosw/components/test/integration/test_dynamo_db_i.py
+++ b/sosw/components/test/integration/test_dynamo_db_i.py
@@ -639,5 +639,27 @@ class DynamodbClientIntegrationTestCase(unittest.TestCase):
         self.assertNotIn('other_col', updated_row)
 
 
+    def test_patch__remove_attrs__without_update(self):
+        keys = {self.HASH_COL:  'cat', self.RANGE_COL: '123'}
+        row = {self.HASH_COL:  'cat', self.RANGE_COL: '123', 'some_col': 'no', 'other_col': 'foo'}
+
+        self.dynamo_client.put(row, self.table_name)
+
+        self.dynamo_client.patch(keys, attributes_to_update={}, table_name=self.table_name,
+                                 attributes_to_remove=['other_col'])
+
+        updated_row = self.dynamo_boto3_client.get_item(
+                Key={self.HASH_COL: {'S': row[self.HASH_COL]},
+                     self.RANGE_COL: {self.RANGE_COL_TYPE: str(row[self.RANGE_COL])}},
+                TableName=self.table_name,
+        )['Item']
+
+        updated_row = self.dynamo_client.dynamo_to_dict(updated_row)
+
+        self.assertIsNotNone(updated_row)
+        self.assertEqual(updated_row['some_col'], 'no'), "Field was not supposed to be updated"
+        self.assertNotIn('other_col', updated_row)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/sosw/components/test/integration/test_dynamo_db_i.py
+++ b/sosw/components/test/integration/test_dynamo_db_i.py
@@ -461,6 +461,22 @@ class DynamodbClientIntegrationTestCase(unittest.TestCase):
         self.assertEqual(result, 3)
 
 
+    def test_get_by_query__expr_attr(self):
+        rows = [
+            {self.HASH_COL: 'cat1', self.RANGE_COL: 121, 'session': 'test1'},
+            {self.HASH_COL: 'cat1', self.RANGE_COL: 122, 'session': 'test2'},
+            {self.HASH_COL: 'cat1', self.RANGE_COL: 123, 'session': 'test3'}
+        ]
+
+        for x in rows:
+            self.dynamo_client.put(x, table_name=self.table_name)
+
+        result = self.dynamo_client.get_by_query({self.HASH_COL: 'cat1'}, table_name=self.table_name,
+                                                 expr_attrs_names=['session'])
+
+        self.assertEqual(result, 3)
+
+
     def test_get_by_query__reverse(self):
         rows = [
             {self.HASH_COL: 'cat1', self.RANGE_COL: 121, 'some_col': 'test1'},

--- a/sosw/components/test/unit/test_dynamo_db.py
+++ b/sosw/components/test/unit/test_dynamo_db.py
@@ -1,4 +1,6 @@
+import datetime
 import logging
+import time
 import unittest
 import os
 from decimal import Decimal
@@ -316,6 +318,43 @@ class dynamodb_client_UnitTestCase(unittest.TestCase):
                                                           table_name=table_name,
                                                           attributes_to_remove=attributes_to_remove,
                                                           condition_expression='attribute_exists hash_col')
+
+
+    def test_sleep_db__get_capacity_called(self):
+        self.dynamo_client.get_capacity = MagicMock(return_value={'read': 10, 'write': 5})
+
+        self.dynamo_client.sleep_db(last_action_time=datetime.datetime.now(), action='write')
+        self.dynamo_client.get_capacity.assert_called_once()
+
+
+    def test_sleep_db__wrong_action(self):
+        self.assertRaises(KeyError, self.dynamo_client.sleep_db, last_action_time=datetime.datetime.now(),
+                          action='call')
+
+    @patch.object(time, 'sleep')
+    def test_sleep_db__fell_asleep(self, mock_sleep):
+        self.dynamo_client.get_capacity = MagicMock(return_value={'read': 10, 'write': 5})
+        # Check that went to sleep
+        time_between_ms = 100
+        last_action_time = datetime.datetime.now() - datetime.timedelta(milliseconds=time_between_ms)
+        self.dynamo_client.sleep_db(last_action_time=last_action_time, action='write')
+        self.assertEqual(mock_sleep.call_count, 1)
+        args, kwargs = mock_sleep.call_args
+
+        # Should sleep around 1 / capacity second minus "time_between_ms" minus code execution time
+        self.assertGreater(args[0], 1 / self.dynamo_client.get_capacity()['write'] - time_between_ms - 0.02)
+        self.assertLess(args[0], 1 / self.dynamo_client.get_capacity()['write'])
+
+
+    @patch.object(time, 'sleep')
+    def test_sleep_db__(self, mock_sleep):
+        self.dynamo_client.get_capacity = MagicMock(return_value={'read': 10, 'write': 5})
+
+        # Shouldn't go to sleep
+        last_action_time = datetime.datetime.now() - datetime.timedelta(milliseconds=900)
+        self.dynamo_client.sleep_db(last_action_time=last_action_time, action='write')
+        # Sleep function should not be called
+        self.assertEqual(mock_sleep.call_count, 0)
 
 
 if __name__ == '__main__':

--- a/sosw/components/test/unit/test_dynamo_db.py
+++ b/sosw/components/test/unit/test_dynamo_db.py
@@ -220,6 +220,20 @@ class dynamodb_client_UnitTestCase(unittest.TestCase):
         self.dynamo_client.dynamo_client.get_paginator.assert_called()
 
 
+    def test_get_by_query__expr_attr(self):
+        keys = {'st_between_range_col': '3', 'en_between_range_col': '6', 'session': 'ses1'}
+        expr_attrs_names = ['range_col', 'session']
+
+        self.dynamo_client = DynamoDbClient(config=self.TEST_CONFIG)
+        self.dynamo_client.get_by_query(keys=keys, expr_attrs_names=expr_attrs_names)
+
+        args, kwargs = self.paginator_mock.paginate.call_args
+        self.assertIn('#range_col', kwargs['ExpressionAttributeNames'])
+        self.assertIn('#session', kwargs['ExpressionAttributeNames'])
+        self.assertIn('#range_col between :st_between_range_col and :en_between_range_col AND #session = :session',
+                      kwargs['KeyConditionExpression'])
+
+
     def test__parse_filter_expression(self):
         TESTS = {
             'key = 42': ("key = :filter_key", {":filter_key": {'N': '42'}}),

--- a/sosw/components/test/unit/test_helpers.py
+++ b/sosw/components/test/unit/test_helpers.py
@@ -666,5 +666,73 @@ class helpers_UnitTestCase(unittest.TestCase):
             to_bool(object())
 
 
+    def test_get_message_dict_from_sns_event(self):
+        TESTS = [
+            {'Records': [{'Sns': {'Message': ''}}]},
+            {'Records': [{'Sns': "{'Message': ''}"}]},
+            {'Records': [{'Sns': {'Message': None}}]},
+            {'Records': [{'Sns': {}}]},
+        ]
+
+        for test in TESTS:
+            self.assertRaises(Exception, get_message_dict_from_sns_event, test)
+
+
+    def test_get_message_dict_from_sns_event(self):
+        sns_event = {
+            'Records': [{
+                'EventSource':          'aws:sns',
+                'EventVersion':         '1.0',
+                'EventSubscriptionArn': 'arn:EventSubscriptionArn',
+                'Sns':                  {
+                    'Type':              'Notification',
+                    'MessageId':         '000000000000',
+                    'TopicArn':          'arn:TopicArn',
+                    'Subject':           'Error 500',
+                    'Message':           '{"Records":[{"eventVersion":"2.0","eventSource":"aws:s3","awsRegion":"us-west-2","s3":{"bucket":{},"object":{}}}]}',
+                    'Timestamp':         '2019-10-13T08:41:52.671Z',
+                    'SignatureVersion':  '1',
+                    'Signature':         'Signature',
+                    'MessageAttributes': {}
+                }
+            }]
+        }
+
+        self.assertEqual(get_message_dict_from_sns_event(sns_event),
+                         {"Records": [{"eventVersion": "2.0", "eventSource": "aws:s3", "awsRegion": "us-west-2", "s3": {"bucket": {}, "object": {}}}]})
+
+
+    def test_is_event_from_sns_false(self):
+        TESTS = [
+            {'Records': [{'Sns': None}]},
+            {'Records': [{'Sns': {}}]},
+            {'Records': [{'Sns': ''}]},
+            {'Records': [{}]},
+            {'Records': ['']},
+            {'Records': ['{}']},
+            {'Records': ['{"Sns": "{"Message": "{}"']}
+        ]
+
+        for test in TESTS:
+            self.assertEqual(is_event_from_sns(test), False)
+
+
+    def test_is_event_from_sns_true(self):
+        TESTS = [
+            {'Records': [{'Sns': {'Message': ''}}]},
+            {'Records': [{'Sns': '{"Message": "{}"'}]}
+        ]
+
+        for test in TESTS:
+            self.assertEqual(is_event_from_sns(test), True)
+
+
+    def test_is_event_from_sns_invalid_events(self):
+        self.assertEqual(is_event_from_sns("{}"), False)
+        self.assertEqual(is_event_from_sns(""), False)
+        self.assertEqual(is_event_from_sns(None), False)
+        self.assertEqual(is_event_from_sns({}), False)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/sosw/test/unit/test_worker.py
+++ b/sosw/test/unit/test_worker.py
@@ -12,7 +12,6 @@ os.environ["autotest"] = "True"
 
 class Worker_UnitTestCase(unittest.TestCase):
 
-
     def setUp(self):
         self.patcher = patch("sosw.app.get_config")
         self.get_config_patch = self.patcher.start()
@@ -27,7 +26,7 @@ class Worker_UnitTestCase(unittest.TestCase):
             pass
 
 
-    def test_close_task__called(self):
+    def test_mark_task_as_completed__called(self):
         with patch('boto3.client'):
             p = Worker()
 

--- a/sosw/test/unit/test_worker_assistant.py
+++ b/sosw/test/unit/test_worker_assistant.py
@@ -31,10 +31,13 @@ class WorkerAssistant_UnitTestCase(unittest.TestCase):
         event = {
             'action':  'mark_task_as_completed',
             'task_id': '123',
+            'stats': {},
+            'result': '{}'
         }
+
         self.worker_assistant.mark_task_as_completed = Mock(return_value=None)
         self.worker_assistant(event)
-        self.worker_assistant.mark_task_as_completed.assert_called_once_with(task_id='123')
+        self.worker_assistant.mark_task_as_completed.assert_called_once_with(task_id='123', stats={}, result='{}')
 
 
     def test_call__mark_task_as_closed__no_task_id__raises(self):

--- a/sosw/test/unit/test_worker_assistant.py
+++ b/sosw/test/unit/test_worker_assistant.py
@@ -31,13 +31,14 @@ class WorkerAssistant_UnitTestCase(unittest.TestCase):
         event = {
             'action':  'mark_task_as_completed',
             'task_id': '123',
-            'stats': {},
-            'result': '{}'
+            'stats': '{"s_key": "value"}',
+            'result': '{"r_key": "value"}'
         }
 
         self.worker_assistant.mark_task_as_completed = Mock(return_value=None)
         self.worker_assistant(event)
-        self.worker_assistant.mark_task_as_completed.assert_called_once_with(task_id='123', stats={}, result='{}')
+        self.worker_assistant.mark_task_as_completed.assert_called_once_with(task_id='123', stats={"s_key": "value"},
+                                                                             result={"r_key": "value"})
 
 
     def test_call__mark_task_as_closed__no_task_id__raises(self):

--- a/sosw/worker.py
+++ b/sosw/worker.py
@@ -49,7 +49,8 @@ class Worker(Processor):
     This is a dictionary with the payload received in the lambda_handler during invocation.
 
     Worker has all the common methods of :ref:`Processor` and tries to mark task as completed if received
-    ``task_id`` in the ``event``.
+    ``task_id`` in the ``event``. Worker create a payload with ``stats`` and ``result`` if exist and invoke worker
+    assistant lambda.
     """
 
     DEFAULT_CONFIG = {
@@ -86,8 +87,15 @@ class Worker(Processor):
         worker_assistant_lambda_name = self.config.get('sosw_worker_assistant_lambda', 'sosw_worker_assistant')
         payload = {
             'action':  'mark_task_as_completed',
-            'task_id': task_id
+            'task_id': task_id,
         }
+
+        if self.stats:
+            payload.update({'stats': self.stats})
+
+        if self.result:
+            payload.update({'result': self.result})
+
         payload = json.dumps(payload)
 
         lambda_response = self.lambda_client.invoke(


### PR DESCRIPTION
* Stats & result of sosw worker call can optionally be saved into the tasks table.
* DynamoDb client - get_by_query - allow querying by reserved keywords (like "session" 😖). [There are ~500 reserved words that normal people are likely to use](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html).
* helpers - check if event is from SNS, extract SNS message from SNS event.