### PR TITLE
Unwrap event recursively from SNS & SQS

### DIFF
--- a/sosw/components/exceptions.py
+++ b/sosw/components/exceptions.py
@@ -1,0 +1,2 @@
+class EventNotFromSourceException(ValueError):
+    pass

--- a/sosw/components/helpers.py
+++ b/sosw/components/helpers.py
@@ -998,7 +998,7 @@ def _unwrap_event_messages(event: Dict, source: str) -> List[Dict]:
     raise EventNotFromSourceException(f"Event is not from {source}, can't unwrap it")
 
 
-def unwrap_event_recursively(event: Dict, sources: Optional[List[str]] = None) -> Union[Dict, List[Dict]]:
+def unwrap_event_recursively(event: Dict, sources: Optional[List[str]] = None) -> List[Dict]:
     """
     Recursively unwraps lambda event from SQS and/or SNS event skeletons.
     Supported sources: 'sqs', 'sns'.
@@ -1014,8 +1014,7 @@ def unwrap_event_recursively(event: Dict, sources: Optional[List[str]] = None) -
     """
 
     messages = [event]
-    sources = sources or ['sns', 'sqs']
-    sources = [x.lower() for x in sources]
+    sources = [x.lower() for x in sources or ['sns', 'sqs']]
     max_depth = 10  # Unwrapping up to depth of 10, as a safety mechanism against infinite loop
 
     for i in range(max_depth):
@@ -1037,4 +1036,4 @@ def unwrap_event_recursively(event: Dict, sources: Optional[List[str]] = None) -
         if original == messages:
             break
 
-    return messages if len(messages) > 1 else messages[0]
+    return messages

--- a/sosw/components/helpers.py
+++ b/sosw/components/helpers.py
@@ -897,6 +897,9 @@ def to_bool(val):
 
 
 def _unwrap_msg_dict_from_sns_event(event) -> Dict:
+    if 'Records' in event and len(event['Records']) > 1:
+        raise ValueError(f"SNS event is not expected to have more than one record. Event: {event}")
+
     try:
         return json.loads(event['Records'][0]['Sns']['Message'])
     except:

--- a/sosw/components/test/unit/helpers_test_variables.py
+++ b/sosw/components/test/unit/helpers_test_variables.py
@@ -1,0 +1,57 @@
+SNS_EVENT = {
+    'Records': [{
+        'EventSource':          'aws:sns',
+        'EventSubscriptionArn': 'arn:aws:sns:us-west-2:000:some_sns:xyz',
+        'Sns':                  {
+            'Type':      'Notification',
+            'MessageId': '111',
+            'TopicArn':  'arn:aws:sns:us-west-2:000:some_topic',
+            'Subject':   'You have some message',
+            'Message':   '{"hello": "I am Inigo Montoya"}',
+        }
+    }]
+}
+
+SNS_NESTED = {
+    'Message':   '{"hello": "I am Inigo Montoya"}',
+    'MessageId': '111',
+    'TopicArn':  'arn:aws:sns:us-west-2:000:some_sns',
+    'Type':      'Notification',
+}
+
+SQS_EVENT = {
+    'Records': [{
+        'body':           '{"hello": "I am Inigo Montoya"}',
+        'eventSource':    'aws:sqs',
+        'eventSourceARN': 'arn:aws:sqs:us-west-2:000:some_queue',
+        'messageId':      '83760',
+        'receiptHandle':  'fgledl9494'
+    }]
+}
+
+EVENT_SNS_INSIDE_SQS = {
+    'Records': [{
+        'messageId':      '111',
+        'receiptHandle':  'abc123',
+        'body':           '{"Message": "{\\"hello\\": \\"I am Inigo Montoya\\"}", "MessageId": "111", "TopicArn": "arn:aws:sns:us-west-2:000:some_sns", "Type": "Notification"}',
+        'eventSource':    'aws:sqs',
+        'eventSourceARN': 'arn:aws:sqs:us-west-2:000:some_sqs',
+        'awsRegion':      'us-west-1'
+    }]
+}
+
+SQS_EVENT_MANY = {
+    'Records': [{
+        'body':           '{"hello": "I am Inigo Montoya"}',
+        'eventSource':    'aws:sqs',
+        'eventSourceARN': 'arn:aws:sqs:us-west-2:000:some_queue',
+        'messageId':      '83760',
+        'receiptHandle':  'fgledl9494'
+    }, {
+        'body':           '{"hello2": "I am Inigo Montoya2"}',
+        'eventSource':    'aws:sqs',
+        'eventSourceARN': 'arn:aws:sqs:us-west-2:000:some_queue',
+        'messageId':      '84732',
+        'receiptHandle':  '85y373'
+    }]
+}

--- a/sosw/components/test/unit/test_helpers.py
+++ b/sosw/components/test/unit/test_helpers.py
@@ -3,6 +3,9 @@ from datetime import timezone
 import time
 import unittest
 import os
+from copy import deepcopy
+
+from sosw.components.test.unit.helpers_test_variables import *
 
 
 os.environ["STAGE"] = "test"
@@ -666,12 +669,15 @@ class helpers_UnitTestCase(unittest.TestCase):
             to_bool(object())
 
 
-    def test_get_message_dict_from_sns_event(self):
+    def test_get_message_dict_from_sns_event__raises(self):
         TESTS = [
             {'Records': [{'Sns': {'Message': ''}}]},
             {'Records': [{'Sns': "{'Message': ''}"}]},
             {'Records': [{'Sns': {'Message': None}}]},
             {'Records': [{'Sns': {}}]},
+            {'Message': '{"...": "..."}', 'TopicArn': ''},
+            {'Message': '', 'TopicArn': 'arn:aws:sns:us-west-2:000:some_topic'},
+            {'Message': 'text message', 'TopicArn': 'arn:aws:sns:us-west-2:000:some_topic'}
         ]
 
         for test in TESTS:
@@ -702,6 +708,13 @@ class helpers_UnitTestCase(unittest.TestCase):
                          {"Records": [{"eventVersion": "2.0", "eventSource": "aws:s3", "awsRegion": "us-west-2", "s3": {"bucket": {}, "object": {}}}]})
 
 
+    def test_get_message_dict_from_sns_event__from_sqs(self):
+        # sqs msg inside sns
+        sns_event = {'Message': '{"hello": "I am Inigo Montoya"}', 'TopicArn': 'arn:aws:sns:us-west-2:000:some_topic'}
+
+        self.assertEqual(get_message_dict_from_sns_event(sns_event), {"hello": "I am Inigo Montoya"})
+
+
     def test_is_event_from_sns_false(self):
         TESTS = [
             {'Records': [{'Sns': None}]},
@@ -718,13 +731,8 @@ class helpers_UnitTestCase(unittest.TestCase):
 
 
     def test_is_event_from_sns_true(self):
-        TESTS = [
-            {'Records': [{'Sns': {'Message': ''}}]},
-            {'Records': [{'Sns': '{"Message": "{}"'}]}
-        ]
-
-        for test in TESTS:
-            self.assertEqual(is_event_from_sns(test), True)
+        self.assertEqual(is_event_from_sns({'Records': [{'Sns': {'Message': '...'}}]}), True)
+        self.assertEqual(is_event_from_sns({'Message': '...', 'TopicArn': 'arn:aws:sns:us-west-2:000:some_topic'}), True)
 
 
     def test_is_event_from_sns_invalid_events(self):
@@ -732,6 +740,42 @@ class helpers_UnitTestCase(unittest.TestCase):
         self.assertEqual(is_event_from_sns(""), False)
         self.assertEqual(is_event_from_sns(None), False)
         self.assertEqual(is_event_from_sns({}), False)
+
+
+    def test_unwrap_event_recursively__not_wrapped(self):
+        event = {"hello": "I am Inigo Montoya"}
+        self.assertEqual(event, unwrap_event_recursively(deepcopy(event)))
+        self.assertEqual(event, unwrap_event_recursively(deepcopy(event), sources=['sns']))
+        self.assertEqual(event, unwrap_event_recursively(deepcopy(event), sources=['sqs']))
+        self.assertEqual(event, unwrap_event_recursively(deepcopy(event), sources=['sns', 'sqs']))
+
+
+    def test_unwrap_event_recursively__sns(self):
+        self.assertEqual({"hello": "I am Inigo Montoya"}, unwrap_event_recursively(deepcopy(SNS_EVENT)))
+
+
+    def test_unwrap_event_recursively__sns2(self):
+        # SNS message inside SQS
+        self.assertEqual({"hello": "I am Inigo Montoya"}, unwrap_event_recursively(SNS_NESTED))
+
+
+    def test_unwrap_event_recursively__sqs_dict(self):
+        self.assertEqual({"hello": "I am Inigo Montoya"}, unwrap_event_recursively(deepcopy(SQS_EVENT)))
+
+
+    def test_unwrap_event_recursively__sns_inside_sqs(self):
+        self.assertEqual({"hello": "I am Inigo Montoya"}, unwrap_event_recursively(deepcopy(EVENT_SNS_INSIDE_SQS)))
+
+
+    def test_is_event_from_sqs__signle(self):
+        self.assertTrue(is_event_from_sqs(SQS_EVENT))
+        self.assertTrue(is_event_from_sqs(SQS_EVENT_MANY))
+        self.assertFalse(is_event_from_sqs(SNS_EVENT))
+
+
+    def test_is_event_from_sqs__many(self):
+        self.assertEqual([{"hello": "I am Inigo Montoya"}, {"hello2": "I am Inigo Montoya2"}],
+                         unwrap_event_recursively(deepcopy(SQS_EVENT_MANY)))
 
 
 if __name__ == '__main__':

--- a/sosw/components/test/unit/test_helpers.py
+++ b/sosw/components/test/unit/test_helpers.py
@@ -683,6 +683,15 @@ class helpers_UnitTestCase(unittest.TestCase):
         for test in TESTS:
             self.assertRaises(Exception, get_message_dict_from_sns_event, test)
 
+    def test_get_message_dict_from_sns_event__many_messages__raises(self):
+        event = deepcopy(SNS_EVENT)
+        event['Records'] = [event['Records'][0], event['Records'][0]]
+
+        with self.assertRaises(ValueError) as assertion_context:
+            get_message_dict_from_sns_event(event)
+
+        self.assertTrue("SNS event is not expected to have more than one record" in str(assertion_context.exception))
+
 
     def test_get_message_dict_from_sns_event(self):
         sns_event = {

--- a/sosw/components/test/unit/test_helpers.py
+++ b/sosw/components/test/unit/test_helpers.py
@@ -744,27 +744,27 @@ class helpers_UnitTestCase(unittest.TestCase):
 
     def test_unwrap_event_recursively__not_wrapped(self):
         event = {"hello": "I am Inigo Montoya"}
-        self.assertEqual(event, unwrap_event_recursively(deepcopy(event)))
-        self.assertEqual(event, unwrap_event_recursively(deepcopy(event), sources=['sns']))
-        self.assertEqual(event, unwrap_event_recursively(deepcopy(event), sources=['sqs']))
-        self.assertEqual(event, unwrap_event_recursively(deepcopy(event), sources=['sns', 'sqs']))
+        self.assertEqual([event], unwrap_event_recursively(deepcopy(event)))
+        self.assertEqual([event], unwrap_event_recursively(deepcopy(event), sources=['sns']))
+        self.assertEqual([event], unwrap_event_recursively(deepcopy(event), sources=['sqs']))
+        self.assertEqual([event], unwrap_event_recursively(deepcopy(event), sources=['sns', 'sqs']))
 
 
     def test_unwrap_event_recursively__sns(self):
-        self.assertEqual({"hello": "I am Inigo Montoya"}, unwrap_event_recursively(deepcopy(SNS_EVENT)))
+        self.assertEqual([{"hello": "I am Inigo Montoya"}], unwrap_event_recursively(deepcopy(SNS_EVENT)))
 
 
     def test_unwrap_event_recursively__sns2(self):
         # SNS message inside SQS
-        self.assertEqual({"hello": "I am Inigo Montoya"}, unwrap_event_recursively(SNS_NESTED))
+        self.assertEqual([{"hello": "I am Inigo Montoya"}], unwrap_event_recursively(SNS_NESTED))
 
 
     def test_unwrap_event_recursively__sqs_dict(self):
-        self.assertEqual({"hello": "I am Inigo Montoya"}, unwrap_event_recursively(deepcopy(SQS_EVENT)))
+        self.assertEqual([{"hello": "I am Inigo Montoya"}], unwrap_event_recursively(deepcopy(SQS_EVENT)))
 
 
     def test_unwrap_event_recursively__sns_inside_sqs(self):
-        self.assertEqual({"hello": "I am Inigo Montoya"}, unwrap_event_recursively(deepcopy(EVENT_SNS_INSIDE_SQS)))
+        self.assertEqual([{"hello": "I am Inigo Montoya"}], unwrap_event_recursively(deepcopy(EVENT_SNS_INSIDE_SQS)))
 
 
     def test_is_event_from_sqs__signle(self):


### PR DESCRIPTION
It's time for us to feel chill about adding pipeline tools (SNS, SQS) before lambdas, without changing the lambda code.