### PR TITLE
Result argument update

### DIFF
--- a/sosw/app.py
+++ b/sosw/app.py
@@ -167,6 +167,7 @@ class Processor:
         # Update the stats for number of calls.
         # Makes sense for Processors initialized outside the scope of `lambda_handler`.
         self.stats['processor_calls'] += 1
+        self.result = defaultdict(int)
 
 
     @staticmethod


### PR DESCRIPTION
We need to clean `self.results` after each call