### PR TITLE
Remove weird characters from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,6 @@
 **sosw** is a set of serverless tools for orchestrating asynchronous invocations of AWS Lambda Functions (Workers).
 
 ---
- Please pronounce **sosw** correctly: _/ˈsɔː səʊ/_
-
----
 
 ## Documentation
 [https://docs.sosw.app](https://docs.sosw.app/en/master/)


### PR DESCRIPTION
pip install sosw fails on windows, and I suspect it's because of this. Not sure though. Worth a try.

```
UnicodeDecodeError: 'charmap' codec can't decode byte 0x90 in position 867: character maps to <undefined>
```