### PR TITLE
Essential config

### DIFF
--- a/sosw/app.py
+++ b/sosw/app.py
@@ -33,8 +33,9 @@ import boto3
 import logging
 import os
 
-from importlib import import_module
 from collections import defaultdict
+from importlib import import_module
+from typing import Dict
 
 from sosw.components.benchmark import benchmark
 from sosw.components.config import get_config
@@ -80,10 +81,15 @@ class Processor:
         self.register_clients(self.config.get('init_clients', []))
 
 
-    def init_config(self, custom_config=None):
+    def init_config(self, custom_config: Dict = None):
         """
-        Init config of the Processor
+        By default tries to initialize config from DEFAULT_CONFIG or as an empty dictionary.
+        After that, a specific custom config of the Lambda will recursively update the existing one.
+        The last step is update config recursively with a passed custom_config.
+
         Overwrite this method if custom logic of recursive updates in configs is required
+
+        :param Dict custom_config: dict with custom configurations
         """
 
         # Initialize config from default config

--- a/sosw/app.py
+++ b/sosw/app.py
@@ -71,6 +71,8 @@ class Processor:
             logger.warning("DEPRECATED: Processor.lambda_context is deprecated. Use global_vars.lambda_context instead")
             self.aws_account = trim_arn_to_account(self.lambda_context.invoked_function_arn)
 
+        self.config = recursive_update(self.config, self.DEFAULT_CONFIG) \
+            if getattr(self, 'config', {}) else self.DEFAULT_CONFIG or {}
         self.config = self.DEFAULT_CONFIG or {}
         self.config = recursive_update(self.config,
                                        self.get_config(f"{os.environ.get('AWS_LAMBDA_FUNCTION_NAME')}_config") or {})

--- a/sosw/essential.py
+++ b/sosw/essential.py
@@ -33,7 +33,6 @@ __version__ = "1.0"
 import logging
 
 from sosw.app import Processor
-from sosw.components.helpers import recursive_update
 
 
 logger = logging.getLogger()
@@ -50,8 +49,5 @@ class Essential(Processor):
     """
 
     def __init__(self, *args, **kwargs):
+        self.config = self.get_config("sosw_essential_config") or {}
         super().__init__(*args, **kwargs)
-        self.config = recursive_update(
-            self.config,
-            self.get_config("sosw_essential_config") or {}
-        )

--- a/sosw/essential.py
+++ b/sosw/essential.py
@@ -31,8 +31,10 @@ __author__ = "Mark Bulgakov"
 __version__ = "1.0"
 
 import logging
+import os
 
 from sosw.app import Processor
+from sosw.components.helpers import *
 
 
 logger = logging.getLogger()
@@ -49,5 +51,22 @@ class Essential(Processor):
     """
 
     def __init__(self, *args, **kwargs):
-        self.config = self.get_config("sosw_essential_config") or {}
+        self.init_config()
         super().__init__(*args, **kwargs)
+
+
+    def init_config(self, custom_config=None):
+        """
+        Overwritten parent method.
+        We expect to receive essential config first, after that all the updates should be done
+        """
+
+        # Initialize config from essential config
+        self.config = self.get_config("sosw_essential_config") or {}
+        #  # Update config recursively from DEFAULT_CONFIG
+        self.config = recursive_update(self.config, self.DEFAULT_CONFIG)
+        # Update config recursively from any existing lambda function config
+        self.config = recursive_update(self.config,
+                                       self.get_config(f"{os.environ.get('AWS_LAMBDA_FUNCTION_NAME')}_config") or {})
+        # Update config recursively from custom config
+        self.config = recursive_update(self.config, custom_config or {})

--- a/sosw/test/integration/test_orchestrator_i.py
+++ b/sosw/test/integration/test_orchestrator_i.py
@@ -26,6 +26,7 @@ class Scheduler_IntegrationTestCase(unittest.TestCase):
 
         self.custom_config = self.TEST_CONFIG.copy()
         self.orchestrator = Orchestrator(self.custom_config)
+        self.get_config_patch.return_value = {}
         self.orchestrator.task_client.ecology_client = MagicMock()
         self.orchestrator.task_client.ecology_client.get_labourer_status.return_value = 4
         self.orchestrator.task_client.ecology_client.count_running_tasks_for_labourer.return_value = 0

--- a/sosw/test/integration/test_orchestrator_i.py
+++ b/sosw/test/integration/test_orchestrator_i.py
@@ -23,10 +23,10 @@ class Scheduler_IntegrationTestCase(unittest.TestCase):
     def setUp(self):
         self.patcher = patch("sosw.app.get_config")
         self.get_config_patch = self.patcher.start()
+        self.get_config_patch.return_value = {}
 
         self.custom_config = self.TEST_CONFIG.copy()
         self.orchestrator = Orchestrator(self.custom_config)
-        self.get_config_patch.return_value = {}
         self.orchestrator.task_client.ecology_client = MagicMock()
         self.orchestrator.task_client.ecology_client.get_labourer_status.return_value = 4
         self.orchestrator.task_client.ecology_client.count_running_tasks_for_labourer.return_value = 0

--- a/sosw/test/integration/test_scheduler_i.py
+++ b/sosw/test/integration/test_scheduler_i.py
@@ -68,6 +68,7 @@ class Scheduler_IntegrationTestCase(unittest.TestCase):
     def setUp(self):
         self.patcher = patch("sosw.app.get_config")
         self.get_config_patch = self.patcher.start()
+        self.get_config_patch.return_value = {}
 
         self.custom_config = self.TEST_CONFIG.copy()
         lambda_context = types.SimpleNamespace()

--- a/sosw/test/integration/test_worker_assistant_i.py
+++ b/sosw/test/integration/test_worker_assistant_i.py
@@ -38,6 +38,7 @@ class WorkerAssistant_IntegrationTestCase(unittest.TestCase):
 
         self.patcher = patch("sosw.app.get_config")
         self.get_config_patch = self.patcher.start()
+        self.get_config_patch.return_value = {}
 
         self.table_name = self.config['dynamo_db_config']['table_name']
         self.HASH_KEY = ('task_id', 'S')

--- a/sosw/test/unit/test_orchestrator.py
+++ b/sosw/test/unit/test_orchestrator.py
@@ -23,8 +23,9 @@ class Orchestrator_UnitTestCase(unittest.TestCase):
     def setUp(self):
         self.patcher = patch("sosw.app.get_config")
         self.get_config_patch = self.patcher.start()
-
+        self.get_config_patch.return_value = {}
         self.custom_config = deepcopy(self.TEST_CONFIG)
+
         with patch('boto3.client'):
             self.orchestrator = Orchestrator(self.custom_config)
 

--- a/sosw/test/unit/test_scheduler.py
+++ b/sosw/test/unit/test_scheduler.py
@@ -73,6 +73,7 @@ class Scheduler_UnitTestCase(unittest.TestCase):
     def setUp(self):
         self.patcher = patch("sosw.app.get_config")
         self.get_config_patch = self.patcher.start()
+        self.get_config_patch.return_value = {}
 
         self.custom_config = deepcopy(self.TEST_CONFIG)
         self.custom_config['siblings_config'] = {


### PR DESCRIPTION
Essential class try to get config, the Processor check now if the `self.config` already exist (it can be, for example, if the class inherits from Essential). If the config is not set yet, then set it as we did before.
It should save from errors with existing implementations, where classes inherits from the `Processor` directly.
