### PR TITLE
v0.7.37

### DIFF
--- a/docs/contribution/convention.rst
+++ b/docs/contribution/convention.rst
@@ -21,6 +21,17 @@ Basics
 * Richard wins against Winnie.
 
 
+Building the docs
+------------------
+
+You can locally build the docs and use the built in python web server to view the html version directly from localhost
+in your preferred browser.
+
+..  code-block:: bash
+
+    sphinx-build -ab html ./docs ./sosw-rtd; (cd sosw-rtd && python -m http.server)
+
+
 Common Sense Boosters
 ---------------------
 

--- a/docs/managers/meta_handler.rst
+++ b/docs/managers/meta_handler.rst
@@ -1,3 +1,5 @@
+.. _meta_handler:
+
 MetaHandler
 -----------
 
@@ -8,6 +10,25 @@ the meta data  automatically. The required schema for the table is described in
 <https://raw.githubusercontent.com/sosw/sosw/master/examples/yaml/initial/sosw-dev-shared-dynamodb.yaml>`_ .
 
 The setup script will create the table by default.
+
+MetaHandler can also be automatically initialised by classes, inheriting from ``Worker``. They will then write
+``'completed'`` and ``'failed'`` events to the DynamoDB tasks meta data table. In order to enable this feature,
+you have to provide ``'meta_handler_config'`` in your custom_config. You will also need to grant write
+permissions for this table to your Lambda.
+
+Config example:
+
+..  code-block:: python
+
+    {
+        'meta_handler_config': {
+            'write_meta_to_ddb': True,
+            'dynamo_db_config': {
+                'table_name':      'sosw_tasks_meta'
+            }
+        }
+    }
+
 
 .. automodule:: sosw.managers.meta_handler
    :members:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as f:
     long_description = f.read()
 
 setup(name='sosw',
-      version='0.7.35',
+      version='0.7.37',
       description='Serverless Orchestrator of Serverless Workers',
       long_description=long_description,
       long_description_content_type="text/markdown",
@@ -22,7 +22,7 @@ setup(name='sosw',
           'Programming Language :: Python :: 3.8',
           'Topic :: Software Development'
       ],
-      packages=find_packages(exclude=['docs', 'test', 'examples', "test/**/*"]),
+      packages=find_packages(exclude=['docs', 'test', 'examples', "*.test", "*.test.*"]),
       install_requires=[
           'boto3>=1.9'
       ],

--- a/sosw/components/decorators.py
+++ b/sosw/components/decorators.py
@@ -27,6 +27,10 @@
 """
 
 import logging
+import time
+
+from typing import Tuple
+from functools import wraps
 
 
 def logging_wrapper(level: int = None):
@@ -75,3 +79,47 @@ def logging_wrapper(level: int = None):
             return result
         return wrapper
     return decorator
+
+
+def retry(exception_to_check: (Exception, Tuple[Exception]) = Exception, tries: int = 4, delay: int = 3,
+          backoff: int = 2):
+    """
+    Retry calling the decorated function using an exponential backoff.
+    Receive amount of retries and time in seconds of a delay between each retry.
+    Based on: http://wiki.python.org/moin/PythonDecoratorLibrary#Retry
+
+    :param exception_to_check: The exception to check or a tuple of exceptions.
+    :param tries: Number of tries
+    :param delay: Delay between retries in seconds
+    :param backoff: backoff multiplier e.g. value of 2 will double the delay
+        each retry
+    """
+
+    assert tries > 0, "Tries must be 1 or greater"
+    assert delay >= 0, "Delay must be greater than 0"
+    assert backoff >= 1, "Backoff must be greater than 1"
+
+
+    def decorator_retry(func):
+        @wraps(func)
+        def func_retry(*args, **kwargs):
+            mutable_tries, mutable_delay = tries, delay
+
+            while mutable_tries > 1:
+                try:
+                    return func(*args, **kwargs)
+                except exception_to_check as e:
+                    msg = f"{str(e)}, Retrying in {mutable_delay} seconds..."
+                    if logging:
+                        logging.warning(msg)
+                    else:
+                        print(msg)
+                    time.sleep(mutable_delay)
+                    mutable_tries -= 1
+                    mutable_delay *= backoff
+
+            return func(*args, **kwargs)
+
+        return func_retry
+
+    return decorator_retry

--- a/sosw/components/dynamo_db.py
+++ b/sosw/components/dynamo_db.py
@@ -26,7 +26,6 @@
     SOFTWARE.
 """
 
-
 __all__ = ['DynamoDbClient', 'clean_dynamo_table']
 __author__ = "Nikolay Grishchenko, Sophie Fogel, Gil Halperin"
 __version__ = "1.6"
@@ -75,6 +74,8 @@ class DynamoDbClient:
         }
 
     """
+
+
     def __init__(self, config):
         assert isinstance(config, dict), "Config must be provided during DynamoDbClient initialization"
 
@@ -104,7 +105,10 @@ class DynamoDbClient:
 
 
     def identify_dynamo_capacity(self, table_name=None):
-        """Identify and store the table capacity for a given table on the object
+        """
+        Identify and store the table capacity for a given table on the object.
+
+        In case the table has ON DEMAND (PAY_PER_REQUEST) BillingMode the ProvisionedThroughput is missing.
 
         Arguments:
             table_name {str} -- short name of the dynamo db table to analyze
@@ -112,19 +116,22 @@ class DynamoDbClient:
         # Use the config value if not provided
         if table_name is None:
             table_name = self.config['table_name']
-            logging.debug("Got `table_name` from config: {table_name}")
+            logging.debug("Got `table_name` from config: %s", table_name)
 
-        logging.debug(f"DynamoDB table name identified as {table_name}")
+        logging.debug("DynamoDB table name identified as %s", table_name)
 
         # Fetch the actual configuration of the dynamodb table directly for
         table_description = self._describe_table(table_name)
-        # Hash to the capacity
-        table_capacity = table_description["Table"]["ProvisionedThroughput"]
 
-        self._table_capacity[table_name] = {
-            'read': int(table_capacity["ReadCapacityUnits"]),
-            'write': int(table_capacity["WriteCapacityUnits"]),
-        }
+        # Hash to the capacity
+        try:
+            table_capacity = table_description["Table"]["ProvisionedThroughput"]
+            self._table_capacity[table_name] = {
+                'read':  int(table_capacity["ReadCapacityUnits"]),
+                'write': int(table_capacity["WriteCapacityUnits"]),
+            }
+        except KeyError:
+            pass
 
 
     def _describe_table(self, table_name: Optional[str] = None) -> Dict:
@@ -138,11 +145,15 @@ class DynamoDbClient:
         table_name = self._get_validate_table_name(table_name)
 
         if self._table_descriptions and table_name in self._table_descriptions:
+            logger.debug("Description taken from cache for table %s: %s ", table_name,
+                         self._table_descriptions[table_name])
             return self._table_descriptions[table_name]
         else:
             table_description = self.dynamo_client.describe_table(TableName=table_name)
             self._table_descriptions[table_name] = table_description
-            return table_description
+            logger.debug("Description for table %s received from API and cached: %s ", table_name,
+                         self._table_descriptions[table_name])
+            return self._table_descriptions[table_name]
 
 
     def get_table_keys(self, table_name: Optional[str] = None) -> Tuple[str, Optional[str]]:
@@ -185,6 +196,9 @@ class DynamoDbClient:
                'index_2_name': ...
            }
 
+        ..  note::
+
+            In case the table has ON DEMAND (PAY_PER_REQUEST) BillingMode the provisioned_throughput is missing.
         """
 
         indexes = {}
@@ -211,22 +225,25 @@ class DynamoDbClient:
                 elif key['KeyType'] == 'RANGE':
                     range_key = key['AttributeName']
 
-            # Get write & read capacity.
-            # global sec. indexes have their own capacities, while a local sec. index uses the capacity of the table.
-            write_capacity = index.get('ProvisionedThroughput', {}).get('WriteCapacityUnits') or \
-                             table_description['ProvisionedThroughput']['WriteCapacityUnits']
-            read_capacity = index.get('ProvisionedThroughput', {}).get('ReadCapacityUnits') or \
-                            table_description['ProvisionedThroughput']['ReadCapacityUnits']
-
             indexes[name] = {
                 'projection_type': projection_type,
-                'hash_key': hash_key,
-                'range_key': range_key,
-                'provisioned_throughput': {
-                    'write_capacity': write_capacity,
-                    'read_capacity': read_capacity
-                }
+                'hash_key':        hash_key,
             }
+
+            if range_key:
+                indexes[name]['range_key'] = range_key
+
+            # Get write & read capacity.
+            # global sec. indexes have their own capacities, while a local sec. index uses the capacity of the table.
+            if index.get('ProvisionedThroughput') or table_description.get('ProvisionedThroughput'):
+                write_capacity = index.get('ProvisionedThroughput', {}).get('WriteCapacityUnits') or \
+                                 table_description['ProvisionedThroughput']['WriteCapacityUnits']
+                read_capacity = index.get('ProvisionedThroughput', {}).get('ReadCapacityUnits') or \
+                                table_description['ProvisionedThroughput']['ReadCapacityUnits']
+                indexes[name]['provisioned_throughput'] = {
+                    'write_capacity': write_capacity,
+                    'read_capacity':  read_capacity
+                }
 
         return indexes
 
@@ -470,7 +487,8 @@ class DynamoDbClient:
 
         cond_expr = " AND ".join(cond_expr_parts)
 
-        select = ('ALL_ATTRIBUTES' if index_name is None else 'ALL_PROJECTED_ATTRIBUTES') if not return_count else 'COUNT'
+        select = (
+            'ALL_ATTRIBUTES' if index_name is None else 'ALL_PROJECTED_ATTRIBUTES') if not return_count else 'COUNT'
 
         logger.debug(cond_expr, filter_values)
         query_args = {
@@ -558,8 +576,10 @@ class DynamoDbClient:
                 f"Unsupported expression for Filtering: {expression}"
             key = words[0]
             result_expr = f"{key} between :st_between_{key} and :en_between_{key}"
-            result_values = self.dict_to_dynamo({f"st_between_{key}": words[2],
-                                                 f"en_between_{key}": words[4]}, add_prefix=':', strict=False)
+            result_values = self.dict_to_dynamo({
+                                                    f"st_between_{key}": words[2],
+                                                    f"en_between_{key}": words[4]
+                                                }, add_prefix=':', strict=False)
         else:
             raise ValueError(f"Unsupported expression for Filtering: {expression}")
 
@@ -704,10 +724,12 @@ class DynamoDbClient:
         # Convert given keys to dynamo syntax
         query_keys = [self.dict_to_dynamo(item) for item in keys_list]
 
+
         # Check if we skipped something - if we did, try again.
         def get_unprocessed_keys(db_result):
             return 'UnprocessedKeys' in db_result and db_result['UnprocessedKeys'] \
                    and table_name in db_result['UnprocessedKeys'] and db_result['UnprocessedKeys'][table_name]['Keys']
+
 
         all_items = []
 
@@ -882,9 +904,9 @@ class DynamoDbClient:
             update_expr_parts.append(remove_expression)
 
         update_item_query = {
-            'Key':                       keys,  # Ex. {'key_name':   'key_value', ...}
-            'TableName':                 table_name,
-            'UpdateExpression':          " ".join(update_expr_parts)  # Ex. "SET #attr_name = :attr_name ..."
+            'Key':              keys,  # Ex. {'key_name':   'key_value', ...}
+            'TableName':        table_name,
+            'UpdateExpression': " ".join(update_expr_parts)  # Ex. "SET #attr_name = :attr_name ..."
         }
 
         if expression_attributes:
@@ -994,6 +1016,7 @@ class DynamoDbClient:
         """
         return self.stats
 
+
     def get_capacity(self, table_name=None):
         """Fetches capacity for data tables
 
@@ -1001,30 +1024,39 @@ class DynamoDbClient:
             table_name {str} -- DynamoDB (default: {None})
 
         Returns:
-            dict -- read/write capacity for the table requested
+            dict -- read/write capacity for the table requested or None for ON_DEMAND (PAY_PER_REQUEST) tables
         """
 
         if table_name is None:
             logging.debug(self.config)
             table_name = self.config['table_name']
 
-        logging.debug(f"DynamoDB table name identified as {table_name}")
+        if table_name not in self._table_descriptions:
+            logger.debug("Getting description from API because not cached yet: %s", table_name)
+            self.identify_dynamo_capacity(table_name=table_name)
 
         if table_name in self._table_capacity.keys():
-            return self._table_capacity[table_name]
-        else:
-            self.identify_dynamo_capacity(table_name=table_name)
+            logger.debug("Found capacity in the cache for table %s: %s", table_name, self._table_capacity[table_name])
             return self._table_capacity[table_name]
 
 
-    def sleep_db(self, last_action_time: datetime.datetime, action: str):
+    def sleep_db(self, last_action_time: datetime.datetime, action: str, table_name=None):
         """
         Sleeps between calls to dynamodb (if it needs to).
         Uses the table's capacity to decide how long it needs to sleep.
+        No need to sleep for ON DEMAND (PAY_PER_REQUEST) tables.
 
         :param last_action_time: Last time when we did this action (read/write) to this dynamo table
         :param action: "read" or "write"
         """
+
+        if table_name is None:
+            logging.debug(self.config)
+            table_name = self.config['table_name']
+
+        # No need to sleep for ON DEMAND (PAY_PER_REQUEST) tables.
+        if not self.get_capacity(table_name=table_name):
+            return
 
         capacity = self.get_capacity()[action]  # Capacity per second
         time_between_actions = 1 / capacity

--- a/sosw/components/dynamo_db.py
+++ b/sosw/components/dynamo_db.py
@@ -261,6 +261,11 @@ class DynamoDbClient:
                 if val_dict:
                     val = val_dict.get(key_type)  # Ex: 1234 or "myvalue"
 
+                    if val is None and key_type not in val_dict:
+                        real_type = list(val_dict.keys())[0]
+                        raise ValueError(f"'{key}' is expected to be of type '{key_type}' in row_mapper, "
+                                         f"but real value is of type '{real_type}'")
+
                     # type_deserializer.deserialize() parses 'N' to `Decimal` type but it cant be parsed to a datetime
                     # so we cast it to either an integer or a float.
                     if key_type == 'N':

--- a/sosw/components/helpers.py
+++ b/sosw/components/helpers.py
@@ -908,13 +908,12 @@ def _unwrap_msg_dict_from_sns_event(event) -> Dict:
         return json.loads(event['Message'])
 
 
-def get_message_dict_from_sns_event(event):
+def get_message_dict_from_sns_event(event: Dict) -> Dict:
     """
     Extract SNS event message and return it loaded as a dict.
 
-    :param dict event: Lambda SNS event (payload). Must be a JSON document.
-    :rtype dict
-    :return: The SNS message, converted to dict
+    :param event:   Lambda SNS event (payload). Must be a JSON document.
+    :return:        The SNS message, converted to dict
     """
 
     if is_event_from_sns(event):

--- a/sosw/components/sns.py
+++ b/sosw/components/sns.py
@@ -30,7 +30,6 @@ __all__ = ['SnsManager']
 __author__ = "Nikolay Grishchenko"
 
 import boto3
-import csv
 import json
 import logging
 import os
@@ -71,6 +70,7 @@ class SnsManager():
 
         self.queue = []
         self.separator = "\n\n#####\n\n"
+        self.message_attributes = None
 
         self.test = kwargs.get('test') or True if os.environ.get('STAGE') == 'test' else False
         if self.test:
@@ -106,6 +106,7 @@ class SnsManager():
     def set_recipient(self, arn):
         assert isinstance(arn, str), f"Invalid format of ARN: {arn}. Recipient must be string ARN of SNS Topic"
         assert arn.lower().startswith('arn:aws:'), f"Invalid format of ARN: {arn}. Recipient must be ARN of SNS Topic"
+
         self.set_client_attr('recipient', value=arn)
 
 
@@ -120,6 +121,15 @@ class SnsManager():
 
         assert isinstance(separator, str), f"Invalid format of separator: {separator}. Separator must be string."
         setattr(self, 'separator', separator)
+
+
+    def set_message_attributes(self, message_attributes):
+        """ Validate attribute value and set new value """
+
+        assert isinstance(message_attributes, dict), f"Invalid format of MessageAttributes: {message_attributes}. " \
+            f"MessageAttributes must be a dict"
+
+        self.set_client_attr('message_attributes', value=message_attributes)
 
 
     def commit(self):
@@ -141,15 +151,65 @@ class SnsManager():
         message = self.separator.join(self.queue)
 
         if message:
+            extra_args = {}
+
+            # Add MessageAttributes to the message if they are defined
+            if self.message_attributes:
+                extra_args['MessageAttributes'] = {
+                    key: self.get_message_attribute(value) for key, value in self.message_attributes.items()
+                }
+
+            logger.info('MessageAttributes: {}'.format(self.message_attributes))
+
             self.client.publish(
                     TopicArn=self.recipient,
                     Subject=self.subject,
-                    Message=message)
+                    Message=message,
+                    **extra_args
+            )
 
         self.queue = []
+        self.message_attributes = None
 
 
-    def send_message(self, message, subject=None, forse_commit=False):
+    def compare_message_attributtes(self, message_attributes):
+        """
+        Compare MessageAttributes. If new object was received - set new value to the attribute
+
+        :param dict message_attributes: Message attributes for SNS subscription filter policies
+        """
+
+        if not self.message_attributes == message_attributes:
+            logger.info("Attribute message_attributes was changed. We set a new one and commit the current queue.")
+            self.set_message_attributes(message_attributes)
+
+
+    @staticmethod
+    def get_message_attribute(attribute):
+        """
+        Amazon SNS compares policy attributes only to message attributes that have the following data types:
+        - String
+        - String.Array
+        - Number
+
+        :return: Type and value of an attribute
+        :rtype: dict
+        """
+
+        if isinstance(attribute, str):
+            return {'DataType': 'String', 'StringValue': attribute}
+
+        if isinstance(attribute, (int, float)):
+            return {'DataType': 'Number', 'StringValue': str(attribute)}
+
+        if hasattr(attribute, '__iter__'):
+            return {'DataType': 'String.Array', 'StringValue': json.dumps(attribute)}
+
+        raise TypeError('Unsupported message_attribute value was passed. Must be one of str, int, float, or iterable. '
+                        'Got {}'.format(type(attribute)))
+
+
+    def send_message(self, message, subject=None, forse_commit=False, message_attributes=None):
         """
         If the subject is not yet set (for example during __init__() of the class) - then require subject to be set.
         Otherwize we accept None subject and simply append messages to queue.
@@ -157,6 +217,8 @@ class SnsManager():
 
         :param str message: Message to be send in body of SNS message. Queued.
         :param str subject: Optional. Custom subject for message.
+        :param bool forse_commit: Commit the queue immediately if True, by default False
+        :param dict message_attributes: Optional. Message attributes for SNS subscription filter policies
         """
 
         if not any([self.subject, subject]):
@@ -166,9 +228,9 @@ class SnsManager():
         if all([self.subject, subject]) and not self.subject == subject:
             logger.info("Change of subject detected. We commit (send) the current queue.")
             self.set_subject(subject)  # This will also commit existing messages automatically.
-            self.queue = [message]
-        else:
-            self.queue.append(message)
+
+        self.compare_message_attributtes(message_attributes)  # This will also commit existing messages automatically.
+        self.queue.append(message)
 
         if forse_commit:
             if subject and not self.subject:

--- a/sosw/components/test/integration/test_dynamo_db_i.py
+++ b/sosw/components/test/integration/test_dynamo_db_i.py
@@ -98,6 +98,17 @@ class DynamodbClientIntegrationTestCase(unittest.TestCase):
             self.dynamo_client.put(row, self.table_name, overwrite_existing=False)
 
 
+    def test_put__create__same_hash_different_range(self):
+        row = {self.HASH_COL: 'cat', self.RANGE_COL: '123'}
+        self.dynamo_client.put(row, self.table_name)
+
+        row[self.RANGE_COL] = '234'
+        self.dynamo_client.put(row, self.table_name, overwrite_existing=False)
+
+        count = self.dynamo_client.get_by_query(keys={self.HASH_COL: 'cat'}, return_count=True)
+        self.assertEqual(count, 2, "The second item was not saved")
+
+
     def test_update__updates(self):
         keys = {self.HASH_COL: 'cat', self.RANGE_COL: '123'}
         row = {self.HASH_COL: 'cat', self.RANGE_COL: '123', 'some_col': 'no', 'other_col': 'foo'}

--- a/sosw/components/test/unit/test_dynamo_db.py
+++ b/sosw/components/test/unit/test_dynamo_db.py
@@ -201,6 +201,21 @@ class dynamodb_client_UnitTestCase(unittest.TestCase):
         self.assertDictEqual(res, expected)
 
 
+    def test_dynamo_to_dict__mapping_doesnt_match__raises(self):
+        # If the value type in the DB doesn't match the expected type in row_mapper - raise ValueError
+
+        dynamo_row = {
+            'hash_col':   {'S': 'aaa'}, 'range_col': {'N': '123'},
+            'other_col': {'N': '111'}  # In the row_mapper, other_col is of type 'S'
+        }
+
+        with self.assertRaises(ValueError) as e:
+            dict_row = self.dynamo_client.dynamo_to_dict(dynamo_row)
+
+        self.assertEqual("'other_col' is expected to be of type 'S' in row_mapper, but real value is of type 'N'",
+                         str(e.exception))
+
+
     def test_get_by_query__validates_comparison(self):
         self.assertRaises(AssertionError, self.dynamo_client.get_by_query, keys={'k': '1'},
                           comparisons={'k': 'unsupported'})

--- a/sosw/components/test/unit/test_dynamo_db.py
+++ b/sosw/components/test/unit/test_dynamo_db.py
@@ -368,10 +368,10 @@ class dynamodb_client_UnitTestCase(unittest.TestCase):
 
 
     def test_sleep_db__get_capacity_called(self):
-        self.dynamo_client.get_capacity = MagicMock(return_value={'read': 10, 'write': 5})
+        self.dynamo_client.dynamo_client = MagicMock()
 
-        self.dynamo_client.sleep_db(last_action_time=datetime.datetime.now(), action='write')
-        self.dynamo_client.get_capacity.assert_called_once()
+        self.dynamo_client.sleep_db(last_action_time=datetime.datetime.now(), action='write', table_name='autotest_new')
+        self.dynamo_client.dynamo_client.describe_table.assert_called_once()
 
 
     def test_sleep_db__wrong_action(self):
@@ -403,6 +403,54 @@ class dynamodb_client_UnitTestCase(unittest.TestCase):
         # Sleep function should not be called
         self.assertEqual(mock_sleep.call_count, 0)
 
+
+    @patch.object(time, 'sleep')
+    def test_sleep_db__returns_none_for_on_demand(self, mock_sleep):
+        self.dynamo_client.dynamo_client = MagicMock()
+        self.dynamo_client.dynamo_client.describe_table.return_value = {'TableName': 'autotest_OnDemand'}
+
+        # Check that went to sleep
+        time_between_ms = 10
+        last_action_time = datetime.datetime.now() - datetime.timedelta(milliseconds=time_between_ms)
+        self.dynamo_client.sleep_db(last_action_time=last_action_time, action='write', table_name='autotest_OnDemand')
+
+        self.assertEqual(mock_sleep.call_count, 0, "Should not have called time.sleep")
+
+
+    def test_on_demand_provisioned_throughput__get_capacity(self):
+        self.dynamo_client.dynamo_client = MagicMock()
+        self.dynamo_client.dynamo_client.describe_table.return_value = {'TableName': 'autotest_OnDemand'}
+
+        result = self.dynamo_client.get_capacity(table_name='autotest_OnDemand')
+        self.assertIsNone(result)
+
+
+    def test_on_demand_provisioned_throughput__get_table_indexes(self):
+        self.dynamo_client.dynamo_client = MagicMock()
+        self.dynamo_client.dynamo_client.describe_table.return_value = {
+            'Table': {
+                'TableName':              'autotest_OnDemandTable',
+                'LocalSecondaryIndexes':  [],
+
+                'GlobalSecondaryIndexes': [
+                    {
+                        'IndexName':  'IndexA',
+                        'KeySchema':  [
+                            {
+                                'AttributeName': 'SomeAttr',
+                                'KeyType':       'HASH',
+                            },
+                        ],
+                        'Projection': {
+                            'ProjectionType': 'ALL',
+                        }
+                    }
+                ]
+            }
+        }
+
+        result = self.dynamo_client.get_table_indexes(table_name='autotest_OnDemandTable')
+        self.assertIsNone(result['IndexA'].get('ProvisionedThroughput'))
 
 if __name__ == '__main__':
     unittest.main()

--- a/sosw/components/test/unit/test_dynamo_db.py
+++ b/sosw/components/test/unit/test_dynamo_db.py
@@ -3,6 +3,7 @@ import logging
 import time
 import unittest
 import os
+from copy import deepcopy
 from decimal import Decimal
 
 from unittest.mock import MagicMock, patch, Mock
@@ -59,6 +60,23 @@ class dynamodb_client_UnitTestCase(unittest.TestCase):
 
     def tearDown(self):
         self.patcher.stop()
+
+
+    def test_create__raises__if_no_hash_col_configured(self):
+        bad_config = deepcopy(self.TEST_CONFIG)
+        del bad_config['hash_key']
+
+        dynamo_client = DynamoDbClient(config=bad_config)
+
+        row = {self.HASH_KEY: 'cat', self.RANGE_KEY: '123'}
+        self.assertRaises(AssertionError, dynamo_client.create, row, self.table_name)
+
+
+    def test_create__calls_boto_client(self):
+        self.dynamo_mock.put_item.assert_not_called()
+
+        self.dynamo_client.put({self.HASH_KEY: 'cat', self.RANGE_KEY: '123'}, self.table_name)
+        self.dynamo_mock.put_item.assert_called_once()
 
 
     def test_dict_to_dynamo_strict(self):

--- a/sosw/components/test/unit/test_sns.py
+++ b/sosw/components/test/unit/test_sns.py
@@ -1,4 +1,5 @@
 import boto3
+import json
 import logging
 import shutil
 import unittest
@@ -122,6 +123,30 @@ class sns_TestCase(unittest.TestCase):
             self.sns.create_subscription('', 'protocol', 'endpoint')
 
         self.assertEqual(str(exc.exception), "You must send valid topic ARN, Protocol and Endpoint to add a subscription")
+
+
+    def test_get_message_attribute_validate_output(self):
+        self.assertEqual(self.sns.get_message_attribute(10), {'DataType': 'Number', 'StringValue': '10'})
+        self.assertEqual(self.sns.get_message_attribute(10.99), {'DataType': 'Number', 'StringValue': '10.99'})
+        self.assertEqual(self.sns.get_message_attribute('Test'), {'DataType': 'String', 'StringValue': 'Test'})
+        self.assertEqual(
+            self.sns.get_message_attribute(['Test1', 'Test2', 'Test3']),
+            {'DataType': 'String.Array', 'StringValue': json.dumps(['Test1', 'Test2', 'Test3'])}
+        )
+
+
+    def test_commit_on_change_message_attributes(self):
+        self.sns.send_message("test message")
+        self.assertEqual(len(self.sns.queue), 1, "There is 1 message in the queue.")
+        self.sns.send_message("test message", message_attributes={'price': 100})
+        self.assertEqual(len(self.sns.queue), 1, "On change message_attributes, old message should be committed, "
+                                                 "new one queued.")
+        self.sns.send_message("test message", message_attributes={'price': 100})
+        self.assertEqual(len(self.sns.queue), 2, "On sending message with exactly same message_attributes, it should "
+                                                 "be queued.")
+        self.sns.send_message("test message", message_attributes={'price': 100, 'cancellation': True})
+        self.assertEqual(len(self.sns.queue), 1, "On sending message with different message_attributes, old messages "
+                                                 "should be committed. New one should be queued.")
 
 
 if __name__ == '__main__':

--- a/sosw/managers/meta_handler.py
+++ b/sosw/managers/meta_handler.py
@@ -55,6 +55,7 @@ class MetaHandler:
         'write_meta_to_ddb': True,
         'dynamo_db_config': {
             'table_name': 'sosw_tasks_meta',
+            'hash_key': 'task_id',
             'row_mapper': {
                 'task_id': 'S',
                 'created_at': 'N',
@@ -104,8 +105,15 @@ class MetaHandler:
     def post(self, task_id: str, action: str, **kwargs):
         """
         Write row with meta data to sosw_tasks_meta DynamoDB Table if configured.
-        As long as collecting the meta data is optional, the ``MetaHandler`` will either save it
+        As long as collecting the meta data is optional, the MetaHandler will either save it
         to DynamoDB or just log.
+
+        MetaHandler does not restrict the fields and actions you can post from your Worker Lambdas with the exception of
+        the following built-in fields. These ones are always taken from the current ``lambda_context`` automatically.
+
+         * ``'author'``
+         * ``'invocation_id'``
+         * ``'log_stream_name'``
         """
 
         row = {

--- a/sosw/managers/task.py
+++ b/sosw/managers/task.py
@@ -325,6 +325,8 @@ class TaskManager(Processor):
         self.dynamo_db_client.put(new_task)
         logger.debug(f"Created a task: {new_task}")
 
+        return new_task
+
 
     def construct_payload_for_task(self, **kwargs) -> str:
         """

--- a/sosw/orchestrator.py
+++ b/sosw/orchestrator.py
@@ -92,7 +92,7 @@ class Orchestrator(Essential):
 
             for task in tasks_to_process:
                 self.task_client.invoke_task(task=task, labourer=labourer)
-                self.meta_handler.post(task_id=task[_('task_id')], action='invoked')
+                self.meta_handler.post(task_id=task[_('task_id')], labourer_id=task[_('labourer_id')], action='invoked')
 
 
     def get_desired_invocation_number_for_labourer(self, labourer: Labourer) -> int:

--- a/sosw/scheduler.py
+++ b/sosw/scheduler.py
@@ -644,7 +644,8 @@ class Scheduler(Essential):
                     task = json.loads(raw_task)
                     labourer = self.task_client.get_labourer(task[_('labourer_id')])
                     new_task = self.task_client.create_task(labourer=labourer, **task)
-                    self.meta_handler.post(task_id=new_task[_('task_id')], action='created', labourer=labourer)
+                    self.meta_handler.post(task_id=new_task[_('task_id')], action='created',
+                                           labourer=task[_('labourer_id')])
                     time.sleep(self._sleeptime_for_dynamo)
 
             else:

--- a/sosw/scheduler.py
+++ b/sosw/scheduler.py
@@ -103,7 +103,8 @@ class Scheduler(Essential):
                 # ('store', {}),
                 # ('product', {}),
             ],
-        }
+        },
+        'task_operational_overhead_for_ddb': 0.03,
     }
 
     # these clients will be initialized by Processor constructor
@@ -638,23 +639,22 @@ class Scheduler(Essential):
                     logger.info(f"No rows in file: {file_name}")
                     break
 
-                for task in data:
-                    logger.debug(f"Pushing task to DynamoDB: {task}")
-                    t = json.loads(task)
-                    labourer = self.task_client.get_labourer(t['labourer_id'])
-                    self.task_client.create_task(labourer=labourer, **t)
-                    self.meta_handler.post(task_id=task[_('task_id')], action='created')
+                for raw_task in data:
+                    logger.debug(f"Pushing task to DynamoDB: {raw_task}")
+                    task = json.loads(raw_task)
+                    labourer = self.task_client.get_labourer(task[_('labourer_id')])
+                    new_task = self.task_client.create_task(labourer=labourer, **task)
+                    self.meta_handler.post(task_id=new_task[_('task_id')], action='created', labourer=labourer)
                     time.sleep(self._sleeptime_for_dynamo)
 
             else:
                 # Spawning another sibling to continue the processing
                 logger.info(f"Ran out of execution time in `process_file`. Spawning sibling.")
+                payload = dict(file_name=file_name)
                 try:
-                    payload = dict(file_name=file_name)
                     self.siblings_client.spawn_sibling(global_vars.lambda_context, payload=payload)
                     self.stats['siblings_spawned'] += 1
-
-                except Exception as err:
+                except Exception:
                     logger.exception(
                             f"Could not spawn sibling with context: {global_vars.lambda_context}, payload: {payload}")
 
@@ -663,15 +663,24 @@ class Scheduler(Essential):
 
 
     @property
-    def _sleeptime_for_dynamo(self):
+    def _sleeptime_for_dynamo(self) -> float:
         """
-        Pull DynamoDB write capcity dynamically to throttle at appropriate levels
+        Pull DynamoDB write capacity dynamically and configure speed of writing.
 
-        Calculates based on the assumption that a single write action consumes a full WCU
-        Therefore multiple capacity units are calculated as a fraction of the
+        Calculates based on the assumption that a single write action consumes a full WCU.
+        It also assumes that the duration of processing the task itself takes some time and decreases sleep accordingly.
+        This duration is theoretically configurable in ``config['task_operational_overhead_for_ddb']``, but after
+        several versions this should probably be removed from config.
+
+        For on-demand billing of the DynamoDB table returns zero.
         """
-        logging.debug(dir(self.task_client.dynamo_db_client))
-        return 1 / self.task_client.dynamo_db_client.get_capacity()['write']
+        try:
+            write_throughput = 1 / self.task_client.dynamo_db_client.get_capacity()['write']
+        except ZeroDivisionError:
+            return 0
+
+        operational_overhead = self.config['task_operational_overhead_for_ddb']
+        return max(write_throughput - operational_overhead, 0)
 
 
     @staticmethod

--- a/sosw/test/integration/test_worker_assistant_i.py
+++ b/sosw/test/integration/test_worker_assistant_i.py
@@ -1,11 +1,13 @@
+import attrdict
 import datetime
-
 import logging
-import unittest
 import os
-from unittest.mock import patch
+import unittest
 
+from sosw.app import global_vars
+from sosw.managers.meta_handler import MetaHandler
 from sosw.worker_assistant import WorkerAssistant
+from unittest.mock import patch
 
 
 logging.getLogger('botocore').setLevel(logging.WARNING)
@@ -27,6 +29,7 @@ class WorkerAssistant_IntegrationTestCase(unittest.TestCase):
         Clean the classic autotest table.
         """
         cls.TEST_CONFIG['init_clients'] = ['DynamoDb']
+        global_vars.lambda_context = attrdict.AttrDict({v: k for k, v in MetaHandler.CONTEXT_FIELDS_MAPPINGS.items()})
 
 
     def setUp(self):

--- a/sosw/test/unit/test_scheduler.py
+++ b/sosw/test/unit/test_scheduler.py
@@ -95,6 +95,7 @@ class Scheduler_UnitTestCase(unittest.TestCase):
         self.scheduler.sns_client = MagicMock()
         self.scheduler.task_client = MagicMock()
         self.scheduler.task_client.get_labourer.return_value = self.LABOURER
+        self.scheduler.get_db_field_name = lambda key: key
         self.scheduler.siblings_client = MagicMock()
         self.scheduler.meta_handler = MagicMock(signature=MetaHandler)
 
@@ -831,10 +832,17 @@ class Scheduler_UnitTestCase(unittest.TestCase):
             'lambda_name':  self.LABOURER.id,
             'some_payload': 'foo',
         }
-
         print(json.dumps(SAMPLE_SIMPLE_JOB))
-        r = self.scheduler(json.dumps(SAMPLE_SIMPLE_JOB))
-        print(r)
+
+        self.scheduler.task_client.create_task.return_value = {'task_id': 123,
+                                                               'labourer_id': SAMPLE_SIMPLE_JOB['lambda_name'],
+                                                               **SAMPLE_SIMPLE_JOB}
+
+        with patch('sosw.scheduler.Scheduler._sleeptime_for_dynamo', new_callable=PropertyMock) as mock_sleeptime:
+            mock_sleeptime.return_value = 0.0001
+
+            r = self.scheduler(json.dumps(SAMPLE_SIMPLE_JOB))
+            print(r)
 
         self.scheduler.task_client.create_task.assert_called_once()
 
@@ -844,3 +852,14 @@ class Scheduler_UnitTestCase(unittest.TestCase):
         self.scheduler.s3_client.upload_file.assert_called_once()
         self.scheduler.s3_client.delete_object.assert_called_once()
 
+
+    def test_sleeptime_for_dynamo(self):
+
+        self.scheduler.task_client.dynamo_db_client.get_capacity.return_value = {'read': 10, 'write': 10}
+        self.assertEqual(round(self.scheduler._sleeptime_for_dynamo, 2), 0.07)
+
+        self.scheduler.task_client.dynamo_db_client.get_capacity.return_value = {'read': 10, 'write': 25}
+        self.assertEqual(round(self.scheduler._sleeptime_for_dynamo, 2), 0.01)
+
+        self.scheduler.task_client.dynamo_db_client.get_capacity.return_value = {'read': 10, 'write': 50}
+        self.assertEqual(round(self.scheduler._sleeptime_for_dynamo, 2), 0)

--- a/sosw/worker_assistant.py
+++ b/sosw/worker_assistant.py
@@ -141,6 +141,7 @@ class WorkerAssistant(Essential):
             keys={_('task_id'): task_id},
             attributes_to_update=fields_to_update,
         )
+        self.meta_handler.post(task_id=task_id, action='marked_as_completed')
 
 
     def mark_task_as_failed(self, task_id: str, stats: Dict = None, result: Dict = None):
@@ -164,6 +165,7 @@ class WorkerAssistant(Essential):
             update_kwargs['attributes_to_update'] = fields_to_update
 
         self.dynamo_db_client.update(**update_kwargs)
+        self.meta_handler.post(task_id=task_id, action='marked_as_failed')
 
 
     def get_db_field_name(self, field: str) -> str:


### PR DESCRIPTION
- dynamo_db: ``create`` - docs and tests
- dynamo_db: support for PAY_PER_REQUEST tables
- meta_handler: added labourer_id where we have it for easier building of reports in the future
- meta_handler: fix default config
- meta_handler: more docs
- worker: cautious support for MetaHandler
- scheduler: configurable sleeptime_for_dynamo coefficient, fix meta_handler calls, support for on-demand tables, test
- task_manager: create_task now returns the new task for post processing after writing to DB.
