### PR TITLE
Scheduler

### DIFF
--- a/sosw/managers/task.py
+++ b/sosw/managers/task.py
@@ -325,6 +325,8 @@ class TaskManager(Processor):
         self.dynamo_db_client.put(new_task)
         logger.debug(f"Created a task: {new_task}")
 
+        return new_task
+
 
     def construct_payload_for_task(self, **kwargs) -> str:
         """

--- a/sosw/orchestrator.py
+++ b/sosw/orchestrator.py
@@ -92,7 +92,7 @@ class Orchestrator(Essential):
 
             for task in tasks_to_process:
                 self.task_client.invoke_task(task=task, labourer=labourer)
-                self.meta_handler.post(task_id=task[_('task_id')], action='invoked')
+                self.meta_handler.post(task_id=task[_('task_id')], labourer_id=task[_('labourer_id')], action='invoked')
 
 
     def get_desired_invocation_number_for_labourer(self, labourer: Labourer) -> int:

--- a/sosw/scheduler.py
+++ b/sosw/scheduler.py
@@ -103,7 +103,8 @@ class Scheduler(Essential):
                 # ('store', {}),
                 # ('product', {}),
             ],
-        }
+        },
+        'task_operational_overhead_for_ddb': 0.03,
     }
 
     # these clients will be initialized by Processor constructor
@@ -638,23 +639,22 @@ class Scheduler(Essential):
                     logger.info(f"No rows in file: {file_name}")
                     break
 
-                for task in data:
-                    logger.debug(f"Pushing task to DynamoDB: {task}")
-                    t = json.loads(task)
-                    labourer = self.task_client.get_labourer(t['labourer_id'])
-                    self.task_client.create_task(labourer=labourer, **t)
-                    self.meta_handler.post(task_id=task[_('task_id')], action='created')
+                for raw_task in data:
+                    logger.debug(f"Pushing task to DynamoDB: {raw_task}")
+                    task = json.loads(raw_task)
+                    labourer = self.task_client.get_labourer(task['labourer_id'])
+                    self.task_client.create_task(labourer=labourer, **task)
+                    self.meta_handler.post(task_id=task[_('task_id')], action='created', labourer=labourer)
                     time.sleep(self._sleeptime_for_dynamo)
 
             else:
                 # Spawning another sibling to continue the processing
                 logger.info(f"Ran out of execution time in `process_file`. Spawning sibling.")
+                payload = dict(file_name=file_name)
                 try:
-                    payload = dict(file_name=file_name)
                     self.siblings_client.spawn_sibling(global_vars.lambda_context, payload=payload)
                     self.stats['siblings_spawned'] += 1
-
-                except Exception as err:
+                except Exception:
                     logger.exception(
                             f"Could not spawn sibling with context: {global_vars.lambda_context}, payload: {payload}")
 
@@ -665,13 +665,14 @@ class Scheduler(Essential):
     @property
     def _sleeptime_for_dynamo(self):
         """
-        Pull DynamoDB write capcity dynamically to throttle at appropriate levels
+        Pull DynamoDB write capacity dynamically and configure speed of writing.
 
-        Calculates based on the assumption that a single write action consumes a full WCU
-        Therefore multiple capacity units are calculated as a fraction of the
+        Calculates based on the assumption that a single write action consumes a full WCU.
+        It also assumes that the duration of processing the task itself takes some time and decreases sleep accordingly.
         """
-        logging.debug(dir(self.task_client.dynamo_db_client))
-        return 1 / self.task_client.dynamo_db_client.get_capacity()['write']
+        write_throughput = 1 / self.task_client.dynamo_db_client.get_capacity()['write']
+        operational_overhead = self.config['task_operational_overhead_for_ddb']
+        return max(write_throughput - operational_overhead, 0)
 
 
     @staticmethod

--- a/sosw/scheduler.py
+++ b/sosw/scheduler.py
@@ -642,9 +642,9 @@ class Scheduler(Essential):
                 for raw_task in data:
                     logger.debug(f"Pushing task to DynamoDB: {raw_task}")
                     task = json.loads(raw_task)
-                    labourer = self.task_client.get_labourer(task['labourer_id'])
-                    self.task_client.create_task(labourer=labourer, **task)
-                    self.meta_handler.post(task_id=task[_('task_id')], action='created', labourer=labourer)
+                    labourer = self.task_client.get_labourer(task[_('labourer_id')])
+                    new_task = self.task_client.create_task(labourer=labourer, **task)
+                    self.meta_handler.post(task_id=new_task[_('task_id')], action='created', labourer=labourer)
                     time.sleep(self._sleeptime_for_dynamo)
 
             else:

--- a/sosw/test/integration/test_worker_assistant_i.py
+++ b/sosw/test/integration/test_worker_assistant_i.py
@@ -1,11 +1,13 @@
+import attrdict
 import datetime
-
 import logging
-import unittest
 import os
-from unittest.mock import patch
+import unittest
 
+from sosw.app import global_vars
+from sosw.managers.meta_handler import MetaHandler
 from sosw.worker_assistant import WorkerAssistant
+from unittest.mock import patch
 
 
 logging.getLogger('botocore').setLevel(logging.WARNING)
@@ -27,6 +29,7 @@ class WorkerAssistant_IntegrationTestCase(unittest.TestCase):
         Clean the classic autotest table.
         """
         cls.TEST_CONFIG['init_clients'] = ['DynamoDb']
+        global_vars.lambda_context = attrdict.AttrDict({v: k for k, v in MetaHandler.CONTEXT_FIELDS_MAPPINGS.items()})
 
 
     def setUp(self):

--- a/sosw/test/unit/test_scheduler.py
+++ b/sosw/test/unit/test_scheduler.py
@@ -844,3 +844,14 @@ class Scheduler_UnitTestCase(unittest.TestCase):
         self.scheduler.s3_client.upload_file.assert_called_once()
         self.scheduler.s3_client.delete_object.assert_called_once()
 
+
+    def test_sleeptime_for_dynamo(self):
+
+        self.scheduler.task_client.dynamo_db_client.get_capacity.return_value = {'read': 10, 'write': 10}
+        self.assertEqual(round(self.scheduler._sleeptime_for_dynamo, 2), 0.07)
+
+        self.scheduler.task_client.dynamo_db_client.get_capacity.return_value = {'read': 10, 'write': 25}
+        self.assertEqual(round(self.scheduler._sleeptime_for_dynamo, 2), 0.01)
+
+        self.scheduler.task_client.dynamo_db_client.get_capacity.return_value = {'read': 10, 'write': 50}
+        self.assertEqual(round(self.scheduler._sleeptime_for_dynamo, 2), 0)

--- a/sosw/worker_assistant.py
+++ b/sosw/worker_assistant.py
@@ -141,6 +141,7 @@ class WorkerAssistant(Essential):
             keys={_('task_id'): task_id},
             attributes_to_update=fields_to_update,
         )
+        self.meta_handler.post(task_id=task_id, action='marked_as_completed')
 
 
     def mark_task_as_failed(self, task_id: str, stats: Dict = None, result: Dict = None):
@@ -164,6 +165,7 @@ class WorkerAssistant(Essential):
             update_kwargs['attributes_to_update'] = fields_to_update
 
         self.dynamo_db_client.update(**update_kwargs)
+        self.meta_handler.post(task_id=task_id, action='marked_as_failed')
 
 
     def get_db_field_name(self, field: str) -> str:


### PR DESCRIPTION
- scheduler: configurable sleeptime_for_dynamo coefficient, fix meta_handler calls, test
- task_manager: create_task now returns the new task for post processing after writing to DB.
- scheduler: _sleeptime_for_dynamo fixed for on-demand billing of tables.
- meta_handler: added labourer_id where we have it for easier building of reports in the future