### PR TITLE
Fix DynamoConfig manager

### DIFF
--- a/docs/components/config.rst
+++ b/docs/components/config.rst
@@ -3,7 +3,15 @@
 Config Source
 -------------
 
-.. automodule:: sosw.components.config
-   :members:
+..  automodule:: sosw.components.config
+    :members:
 
+..  autoclass:: sosw.components.config.DynamoConfig
+    :members:
+
+..  autoclass:: sosw.components.config.SecretsManager
+    :members:
+
+..  autoclass:: sosw.components.config.SSMConfig
+    :members:
 

--- a/extras/README.md
+++ b/extras/README.md
@@ -14,7 +14,7 @@ Make sure that you:
 - Create a PR to master from this branch.
 
 ## Docs build
-- Make sure that the secrets for `.github/workflows` are up to date.
+- Make sure that the secrets for `.github/workflows` are up-to-date.
 - Make sure that you have the docs hosted in some reliable location.
 - Make sure that DNS points to that location.
 - RTFM the guidelines of how to publish `sosw` docs and follow recommendations.

--- a/sosw/app.py
+++ b/sosw/app.py
@@ -69,7 +69,7 @@ class Processor:
     def __init__(self, custom_config=None, **kwargs):
         """
         Initialize the Processor.
-        Updates the default config with parameters from SSM, then from provided custom config (usually from event).
+        Recursively Updates the default config with parameters from DynamoDB / SSM, then from provided custom config.
         """
 
         self.test = kwargs.get('test') or True if os.environ.get('STAGE') in ['test', 'autotest'] else False

--- a/sosw/app.py
+++ b/sosw/app.py
@@ -90,7 +90,7 @@ class Processor:
 
     def init_config(self, custom_config: Dict = None):
         """
-        By default tries to initialize config from DEFAULT_CONFIG or as an empty dictionary.
+        By default, tries to initialize config from DEFAULT_CONFIG or as an empty dictionary.
         After that, a specific custom config of the Lambda will recursively update the existing one.
         The last step is update config recursively with a passed custom_config.
 
@@ -262,7 +262,7 @@ class Processor:
         Return statistics of operations performed by current instance of the Class.
 
         Statistics of custom clients existing in the Processor is also aggregated by default.
-        Clients must be initialized as `self.some_client` ending with `_client` suffix (e.g. self.dynamo_client).
+        Clients must be initialized as `self.some_client` ending with `_client` suffix (e.g. self.dynamo_db_client).
         Clients must also have their own get_stats() methods implemented.
 
         Be careful about circular get_stats() calls from child classes.
@@ -286,7 +286,7 @@ class Processor:
                 except Exception:
                     logger.debug(f"{some_client} doesn't have get_stats() implemented. Recommended to fix this.")
 
-        return self.stats
+        return dict(self.stats)
 
 
     def reset_stats(self, recursive: bool = True):

--- a/sosw/components/benchmark.py
+++ b/sosw/components/benchmark.py
@@ -36,10 +36,20 @@ import time
 def benchmark(fn):
     """
     Decorator that should be used on class methods that you want to benchmark.
-    It will aggregate to `self.stats` of the class timing of decorated functions.
+    It will aggregate to `self.stats` of the Processor class timing of decorated functions.
 
     | `fn` - pointer to class function. Class is not yet initialized.
     | `self` - pointer to class instance. Passed during the call of decorated method.
+
+    Usage example:
+
+    ..  code-block:: python
+
+        class Processor(SoswProcessor):
+
+            @benchmark
+            def make_query_to_db(self):
+                ...
     """
 
 

--- a/sosw/components/test/test_config.py
+++ b/sosw/components/test/test_config.py
@@ -6,7 +6,8 @@ from unittest.mock import patch, MagicMock
 
 from sosw.components.dynamo_db import DynamoDbClient
 from sosw.components.config import SSMConfig, DynamoConfig, ConfigSource
-from sosw.test.helpers_test_dynamo_db import AutotestDdbManager, autotest_dynamo_db_config_setup, get_autotest_ddb_name_with_custom_suffix
+from sosw.test.helpers_test_dynamo_db import AutotestDdbManager, autotest_dynamo_db_config_setup, \
+    get_autotest_ddb_name_with_custom_suffix, safe_put_to_ddb
 
 logging.getLogger('botocore').setLevel(logging.WARNING)
 
@@ -68,26 +69,20 @@ class DynamoConfigTestCase(unittest.TestCase):
         asyncio.run(cls.autotest_ddbm.drop_ddbs())
 
 
-    @unittest.skip("TODO need normal patching")
     def test_get_config__json(self):
         row = {'env': 'production', 'config_name': 'sophie_test', 'config_value': '{"a": 1}'}
-        self.dynamo_client.put(row)
+        safe_put_to_ddb(row, self.dynamo_client)
 
-        config = self.dynamo_config.get_config('sophie_test', "production")
+        result = self.dynamo_config.get_config('sophie_test', "production")
+        self.assertEqual(result, {'a': 1})
 
-        self.assertEqual(config, {'a': 1})
 
-
-    @unittest.skip("TODO need normal patching")
     def test_get_config__str(self):
-        def get_by_query(*args, **kwargs):
-            return [{'env': 'production', 'config_name': 'sophie_test2', 'config_value': 'some text'}]
+        row = {'env': 'production', 'config_name': 'sophie_test2', 'config_value': 'some text'}
+        safe_put_to_ddb(row, self.dynamo_client)
 
-
-        self.dynamo_config.dynamo_client = FakeDynamo
-        with patch.object(FakeDynamo, 'get_by_query', new=get_by_query):
-            config = self.dynamo_config.get_config('sophie_test2', "production")
-            self.assertEqual(config, 'some text')
+        result = self.dynamo_config.get_config('sophie_test2', "production")
+        self.assertEqual(result, 'some text')
 
 
     def test_get_config__doesnt_exist(self):
@@ -104,7 +99,7 @@ class DynamoConfigTestCase(unittest.TestCase):
         ]
 
         for row in SAMPLES:
-            self.dynamo_client.put(row)
+            safe_put_to_ddb(row, self.dynamo_client)
 
         result = self.dynamo_config.get_credentials_by_prefix('testing')
 


### PR DESCRIPTION
- Ignore missing DDB permissions during `Processor.__init__`.
- return `get_stats` as `dict` instead of `defaultdict` 
- `get_secrets_credentials`: available to import and used from `ConfigSource`
- Passing `kwargs` in `get_credentials_by_prefix` and `get_config`.
- components.benchmark: documentation
- components.config: Improved documentation.

 Fix #283 
 Fix #287 
 Fix #322